### PR TITLE
chore: add benchmarks and update README for Bloom filter

### DIFF
--- a/bloom/bloom_benchmark_test.go
+++ b/bloom/bloom_benchmark_test.go
@@ -1,0 +1,41 @@
+package bloom
+
+import (
+	"testing"
+	"log/slog"
+	"os"
+)
+
+func BenchmarkBloomFilterAdd(b *testing.B) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	bf := NewBloomFilter(1000, 3, logger)
+	element := []byte("benchmark")
+
+	for i := 0; i < b.N; i++ {
+		bf.Add(element)
+	}
+}
+
+func BenchmarkBloomFilterContains(b *testing.B) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	bf := NewBloomFilter(1000, 3, logger)
+	element := []byte("benchmark")
+	bf.Add(element)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bf.Contains(element)
+	}
+}
+
+func BenchmarkOptimalSize(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		OptimalSize(1000, 0.01)
+	}
+}
+
+func BenchmarkOptimalHashFunctions(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		OptimalHashFunctions(1000, 100)
+	}
+}


### PR DESCRIPTION
- Added benchmark tests for Bloom filter operations in `bloom_benchmark_test.go`
  - Benchmarks for Add operation
  - Benchmarks for Contains operation
  - Benchmarks for OptimalSize calculation
  - Benchmarks for OptimalHashFunctions calculation
- Updated README to include detailed setup instructions, usage examples, and guidelines
  - Added sections for build and test instructions
  - Included step-by-step implementation guide
  - Documented contribution process and issue reporting
  - Ensured compliance with Go project best practices

This commit enhances the project's documentation and provides performance benchmarks for key Bloom filter operations.